### PR TITLE
fix: do not use "Content-Encoding" header as buffer encoding

### DIFF
--- a/src/HttpMessage.ts
+++ b/src/HttpMessage.ts
@@ -97,12 +97,8 @@ export class HttpMessage {
   ) {
     const fetchHeaders = new Headers(this.rawHeaders)
 
-    this.encoding = (fetchHeaders.get('Content-Encoding') ||
-      undefined) as BufferEncoding
-
     this.mimeType = fetchHeaders.get('Content-Type') || ''
-    this.bodySize =
-      body == null ? 0 : Buffer.from(body, this.encoding).byteLength
+    this.bodySize = body == null ? 0 : Buffer.from(body).byteLength
 
     const headerLines = toHeaderLines(this.rawHeaders)
 


### PR DESCRIPTION
The `Content-Encoding` response header is not the same thing as the Buffer encoding in Node.js. Using it as the Buffer encoding will throw (e.g. `Content-Encoding: gzip`). 